### PR TITLE
Hide RapidAPI Key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.pnp
 .pnp.js
 
+# env files
+.env
+
 # testing
 /coverage
 

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react';
 import Weather from './components/Weather';
 import LoadingIndicator from './UI/LoadingIndicator';
 
+require('dotenv').config();
+
 import './app.css';
 
 function App() {
@@ -16,6 +18,8 @@ function App() {
   function handleSearch(e) {
     setSearch(e.target.value);
   }
+
+  const apiKey = process.env.REACT_APP_RAPIDAPI_KEY;
 
   async function geoHandler() {
     setSearch('');
@@ -32,7 +36,7 @@ function App() {
     const options = {
       method: 'GET',
       headers: {
-        'X-RapidAPI-Key': '0173291af0msh62b3ca25953f210p13d732jsn66b4d9f97708',
+        'X-RapidAPI-Key': apiKey,
         'X-RapidAPI-Host': 'weatherapi-com.p.rapidapi.com',
       },
     };


### PR DESCRIPTION
This pull request enhances the security of our application by implementing a more secure method for handling the RapidAPI key.
Moved the RapidAPI key to an environment variable stored in the .env file.
Accessed the API key using process.env within the code, ensuring it remains hidden from version control.
install dotenv using 'npm install dotenv' and create a .env file which contains your rapid api key

REACT_APP_RAPIDAPI_KEY=<Your key>